### PR TITLE
Release action change

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         run: cross build --release
 
   # Release Lib to crates.io
-  release-lib:
+  release-lib-crates:
     name: Release Lib to crates.io
     runs-on: ubuntu-latest
     needs: [tag-release]
@@ -81,7 +81,7 @@ jobs:
   release-cli-crates:
     name: Release CLI to crates.io
     runs-on: ubuntu-latest
-    needs: [release-lib]
+    needs: [release-lib-crates]
     if: github.ref_type == 'tag' && ( contains(github.ref_name, '-') == false ) 
     strategy:
       matrix:
@@ -104,11 +104,32 @@ jobs:
       #     CARGO_REGISTRY_TOKEN: "${{ secrets.CRATES_TOKEN }}"
       #   run: cargo publish -p alienware_cli
 
+  # Create the release artifacts in GitHub
+  release-gh:
+    name: Create the release artifacts in GitHub
+    runs-on: ubuntu-latest
+    needs: [tag-release]
+    # if: github.ref_type == 'tag' && ( contains(github.ref_name, '-') == false ) 
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Create CLI Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: "${{ github.ref_name }}"
+          name: "Release ${{ github.ref_name }}"
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          files: |
+            LICENSE
+            target/release/alienware-cli
+
   # Kick off the workflow in this repo that will generate the snapcraft yaml file 
   # release-cli-snap:
   #   name: Initiate release of the alienware cli application
   #   runs-on: ubuntu-latest
-  #   needs: [tag-release]
+  #   needs: [release-cli-crates]
 
   #   steps:
   #     - name: Repository Dispatch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,10 +58,10 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.TARGET }}
 
-      # - name: Publish API to crates.io
-      #   env:
-      #     CARGO_REGISTRY_TOKEN: "${{ secrets.CRATES_TOKEN }}"
-      #   run: cargo publish -p alienware
+      - name: Publish API to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: "${{ secrets.CRATES_TOKEN }}"
+        run: cargo publish -p alienware
 
       - name: Create CLI Release
         uses: softprops/action-gh-release@v1
@@ -99,17 +99,17 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.TARGET }}
 
-      # - name: Publish CLI to crates.io
-      #   env:
-      #     CARGO_REGISTRY_TOKEN: "${{ secrets.CRATES_TOKEN }}"
-      #   run: cargo publish -p alienware_cli
+      - name: Publish CLI to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: "${{ secrets.CRATES_TOKEN }}"
+        run: cargo publish -p alienware_cli
 
   # Create the release artifacts in GitHub
   release-gh:
     name: Create the release artifacts in GitHub
     runs-on: ubuntu-latest
     needs: [tag-release]
-    # if: github.ref_type == 'tag' && ( contains(github.ref_name, '-') == false ) 
+    if: github.ref_type == 'tag' && ( contains(github.ref_name, '-') == false ) 
 
     steps:
       - name: Checkout
@@ -126,17 +126,18 @@ jobs:
             target/release/alienware-cli
 
   # Kick off the workflow in this repo that will generate the snapcraft yaml file 
-  # release-cli-snap:
-  #   name: Initiate release of the alienware cli application
-  #   runs-on: ubuntu-latest
-  #   needs: [release-cli-crates]
+  release-cli-snap:
+    name: Initiate release of the alienware cli application
+    runs-on: ubuntu-latest
+    needs: [release-cli-crates]
+    if: github.ref_type == 'tag' && ( contains(github.ref_name, '-') == false )
 
-  #   steps:
-  #     - name: Repository Dispatch
-  #       uses: benc-uk/workflow-dispatch@v1
-  #       with:
-  #         token: ${{ secrets.PAT }}
-  #         repo: a1ecbr0wn/alienware-wmi
-  #         ref: refs/heads/main
-  #         workflow: snap.yml
-  #         inputs: '{ "snap_version": "${{ github.ref_name }}" }'
+    steps:
+      - name: Repository Dispatch
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          token: ${{ secrets.PAT }}
+          repo: a1ecbr0wn/alienware-wmi
+          ref: refs/heads/main
+          workflow: snap.yml
+          inputs: '{ "snap_version": "${{ github.ref_name }}" }'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,10 +58,10 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.TARGET }}
 
-      - name: Publish API to crates.io
-        env:
-          CARGO_REGISTRY_TOKEN: "${{ secrets.CRATES_TOKEN }}"
-        run: cargo publish -p alienware
+      # - name: Publish API to crates.io
+      #   env:
+      #     CARGO_REGISTRY_TOKEN: "${{ secrets.CRATES_TOKEN }}"
+      #   run: cargo publish -p alienware
 
       - name: Create CLI Release
         uses: softprops/action-gh-release@v1
@@ -99,10 +99,10 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.TARGET }}
 
-      - name: Publish CLI to crates.io
-        env:
-          CARGO_REGISTRY_TOKEN: "${{ secrets.CRATES_TOKEN }}"
-        run: cargo publish -p alienware_cli
+      # - name: Publish CLI to crates.io
+      #   env:
+      #     CARGO_REGISTRY_TOKEN: "${{ secrets.CRATES_TOKEN }}"
+      #   run: cargo publish -p alienware_cli
 
   # Kick off the workflow in this repo that will generate the snapcraft yaml file 
   # release-cli-snap:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Build
         run: cross build --release
 
+  # Release Lib to crates.io
   release-lib:
     name: Release Lib to crates.io
     runs-on: ubuntu-latest
@@ -63,12 +64,11 @@ jobs:
         run: cargo publish -p alienware
 
       - name: Create CLI Release
-        uses: marvinpinto/action-automatic-releases@latest
+        uses: softprops/action-gh-release@v1
         with:
-          automatic_release_tag: "latest"
-          title: "Release ${{ github.ref_name }}"
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          prerelease: false
+          tag_name: "${{ github.ref_name }}"
+          name: "Release ${{ github.ref_name }}"
+          token: "${{ secrets.GITHUB_TOKEN }}"
           files: |
             LICENSE
             target/release/alienware-cli
@@ -77,6 +77,7 @@ jobs:
         run: sleep 10s
         shell: bash
 
+  # Release CLI to crates.io
   release-cli-crates:
     name: Release CLI to crates.io
     runs-on: ubuntu-latest
@@ -104,17 +105,17 @@ jobs:
         run: cargo publish -p alienware_cli
 
   # Kick off the workflow in this repo that will generate the snapcraft yaml file 
-  release-cli-snap:
-    name: Initiate release of the alienware cli application
-    runs-on: ubuntu-latest
-    needs: [tag-release]
+  # release-cli-snap:
+  #   name: Initiate release of the alienware cli application
+  #   runs-on: ubuntu-latest
+  #   needs: [tag-release]
 
-    steps:
-      - name: Repository Dispatch
-        uses: benc-uk/workflow-dispatch@v1
-        with:
-          token: ${{ secrets.PAT }}
-          repo: a1ecbr0wn/alienware-wmi
-          ref: refs/heads/main
-          workflow: snap.yml
-          inputs: '{ "snap_version": "${{ github.ref_name }}" }'
+  #   steps:
+  #     - name: Repository Dispatch
+  #       uses: benc-uk/workflow-dispatch@v1
+  #       with:
+  #         token: ${{ secrets.PAT }}
+  #         repo: a1ecbr0wn/alienware-wmi
+  #         ref: refs/heads/main
+  #         workflow: snap.yml
+  #         inputs: '{ "snap_version": "${{ github.ref_name }}" }'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,4 @@ members = [
     "alienware_cli",
     "alienware",
 ]
+resolver = "2"


### PR DESCRIPTION
Change the unsupported `marvinpinto/action-automatic-releases` action and replace with `softprops/action-gh-release` which has been updated to support the latest node16 requirement.